### PR TITLE
EDDN

### DIFF
--- a/src/traikoa.cr
+++ b/src/traikoa.cr
@@ -2,5 +2,52 @@ require "./traikoa/*"
 
 module Traikoa
   client = EDDN::Client.new
+
+  client.on_packet do |packet|
+    header = packet.header
+
+    event_type = EDDN::PAYLOAD[packet.schema_ref]?
+
+    system_name = nil
+    station_name = nil
+    position = [] of Float64
+
+    # Read the specific `Journal` event type
+    event_string = if event_type == EDDN::Journal
+                     object = packet.read_event.as(EDDN::Journal::Common)
+                     system_name = object.star_system
+                     position = object.star_position
+                     if object.responds_to?(:station_name)
+                       station_name = object.station_name
+                     end
+                     object.event
+                   elsif event_type
+                     event_type.to_s.split("::").last
+                   else
+                     "Unsupported"
+                   end
+
+    if event_type == EDDN::Commodity::Market
+      object = packet.read_event
+      system_name = object.as(EDDN::Commodity::Market).system_name
+      station_name = object.as(EDDN::Commodity::Market).station_name
+    end
+
+    packet.message.rewind
+
+    Database::EddnLog.create({
+      gateway_timestamp: header.gateway_timestamp,
+      type:              event_string,
+      uploader_id:       header.uploader_id,
+      software_name:     header.software_name,
+      software_version:  header.software_version,
+      schema_ref:        packet.schema_ref,
+      system_name:       system_name,
+      system_position:   position,
+      station_name:      station_name,
+      message:           packet.message.to_s,
+    })
+  end
+
   client.run!
 end

--- a/src/traikoa/database.cr
+++ b/src/traikoa/database.cr
@@ -6,3 +6,4 @@ Jennifer::Config.read("database.yml", :development)
 require "./database/utils"
 require "./database/system"
 require "./database/faction"
+require "./database/eddn_log"

--- a/src/traikoa/database/eddn_log.cr
+++ b/src/traikoa/database/eddn_log.cr
@@ -1,0 +1,19 @@
+module Traikoa::Database
+  class EddnLog < Jennifer::Model::Base
+    table_name :eddn_logs
+
+    mapping({
+      id:                {type: Int32, primary: true},
+      gateway_timestamp: {type: Time},
+      type:              String,
+      uploader_id:       String,
+      software_name:     String,
+      software_version:  String,
+      schema_ref:        String,
+      system_name:       {type: String, null: true},
+      system_position:   {type: Array(Float64), null: true},
+      station_name:      {type: String, null: true},
+      message:           String,
+    })
+  end
+end

--- a/src/traikoa/database/migrations/20170926204517557_eddn_logs.cr
+++ b/src/traikoa/database/migrations/20170926204517557_eddn_logs.cr
@@ -1,0 +1,55 @@
+class EddnLogs20170926204517557 < Jennifer::Migration::Base
+  def up
+    exec <<-SQL
+    CREATE TYPE eddn_event AS ENUM (
+      'Docked',
+      'FSDJump',
+      'Location',
+      'Scan',
+      'CommodityMarket',
+      'Blackmarket',
+      'Shipyard',
+      'Outfitting',
+      'Unsupported'
+    );
+    SQL
+
+    exec <<-SQL
+    CREATE TABLE eddn_logs (
+      id SERIAL PRIMARY KEY,
+      gateway_timestamp TIMESTAMPTZ NOT NULL,
+      type EDDN_EVENT NOT NULL,
+      uploader_id TEXT NOT NULL,
+      software_name TEXT NOT NULL,
+      software_version TEXT NOT NULL,
+      schema_ref TEXT NOT NULL,
+      system_name TEXT,
+      system_position FLOAT[],
+      station_name TEXT,
+      message TEXT NOT NULL
+    );
+    SQL
+
+    exec <<-SQL
+    CREATE INDEX eddn_logs_gateway_timestamp_idx ON eddn_logs (gateway_timestamp);
+    SQL
+
+    exec <<-SQL
+    CREATE INDEX eddn_logs_type_idx ON eddn_logs (type);
+    SQL
+
+    exec <<-SQL
+    CREATE INDEX eddn_logs_schema_ref_idx ON eddn_logs (schema_ref);
+    SQL
+  end
+
+  def down
+    exec <<-SQL
+    DROP TABLE IF EXISTS eddn_logs;
+    SQL
+
+    exec <<-SQL
+    DROP TYPE IF EXISTS eddn_event
+    SQL
+  end
+end

--- a/src/traikoa/database/migrations/20170926204517557_eddn_logs.cr
+++ b/src/traikoa/database/migrations/20170926204517557_eddn_logs.cr
@@ -45,11 +45,11 @@ class EddnLogs20170926204517557 < Jennifer::Migration::Base
 
   def down
     exec <<-SQL
-    DROP TABLE IF EXISTS eddn_logs;
+    DROP TABLE eddn_logs;
     SQL
 
     exec <<-SQL
-    DROP TYPE IF EXISTS eddn_event
+    DROP TYPE eddn_event;
     SQL
   end
 end

--- a/src/traikoa/eddn/client.cr
+++ b/src/traikoa/eddn/client.cr
@@ -90,9 +90,12 @@ module Traikoa
               handler.call(object)
             rescue ex
               LOGGER.error <<-LOG
-                An exception occured in a gateway object handler!
-                #{ex}
+                An unhandled exception occured in a gateway object handler!
+                Exception: #{ex}
+                Object: #{object.inspect}
+                #{"Packet message: #{object.message.to_s}" if object.is_a?(Packet)}
                 LOG
+              raise ex
             end
           end
         end

--- a/src/traikoa/eddn/data.cr
+++ b/src/traikoa/eddn/data.cr
@@ -73,6 +73,7 @@ module Traikoa
         "Docked",
         "FSDJump",
         "Scan",
+        "Location",
       }
 
       TIME_FORMAT = Time::Format.new("%FT%TZ")
@@ -83,6 +84,7 @@ module Traikoa
         # Extends the base `JSON.mapping` with the common attributs
         macro mapping(**properties)
           JSON.mapping(
+            event: String,
             timestamp: {type: Time, converter: TIME_FORMAT},
             star_system: {key: "StarSystem", type: String},
             star_position: {key: "StarPos", type: Array(Float64)},
@@ -103,8 +105,8 @@ module Traikoa
         )
       end
 
-      # Data object for an EDDN Journal `FSDJump` event
-      struct FSDJump < Common
+      # Data object for an EDDN Journal `FSDJump` and `Location` events
+      struct FSDJumpLocation < Common
         mapping(
           security: {key: "SystemSecurity", type: String, converter: Localizer::Security},
           allegiance: {key: "SystemAllegiance", type: String},
@@ -114,9 +116,16 @@ module Traikoa
           controlling_faction_state: {key: "FactionState", type: String?, converter: Localizer::Factionstate},
           controlling_faction: {key: "SystemFaction", type: String?},
           controlling_faction_government: {key: "SystemGovernment", type: String?, converter: Localizer::Government},
-          factions: {key: "Factions", type: Array(Faction)?}
+          factions: {key: "Factions", type: Array(Faction)?},
+          docked: {key: "Docked", type: Bool?},
+          station_type: {key: "StationType", type: String?},
+          station_name: {key: "StationName", type: String?}
         )
       end
+
+      # Aliases for easy decoding
+      alias FSDJump = FSDJumpLocation
+      alias Location = FSDJumpLocation
 
       # Data object for an EDDN Journal `Scan` event
       struct Scan < Common
@@ -126,7 +135,7 @@ module Traikoa
           mass: {key: "MassEM", type: Float64?},
           planet_class: {key: "PlanetClass", type: String?},
           surface_pressure: {key: "SurfacePressure", type: Float64?},
-          rotation_period: {key: "RotationPeriod", type: Float64},
+          rotation_period: {key: "RotationPeriod", type: Float64?},
           orbital_period: {key: "OrbitalPeriod", type: Float64?},
           eccentricity: {key: "Eccentricity", type: Float64?},
           atmosphere_type: {key: "AtmosphereType", type: String?},
@@ -140,7 +149,7 @@ module Traikoa
           atmosphere: {key: "Atmosphere", type: String?},
           orbital_inclination: {key: "OrbitalInclination", type: Float64?},
           landable: {key: "Landable", type: Bool?},
-          radius: {key: "Radius", type: Float64},
+          radius: {key: "Radius", type: Float64?},
           absolute_magnitude: {key: "AbsoluteMagnitude", type: Float64?},
           distance_from_arrival: {key: "DistanceFromArrivalLS", type: Float64},
           surface_gravity: {key: "SurfaceGravity", type: Float64?},

--- a/src/traikoa/eddn/data.cr
+++ b/src/traikoa/eddn/data.cr
@@ -157,7 +157,8 @@ module Traikoa
           surface_gravity: {key: "SurfaceGravity", type: Float64?},
           stellar_mass: {key: "StellarMass", type: Float64?},
           star_type: {key: "StarType", type: String?},
-          age: {key: "Age_MY", type: Int64?}
+          age: {key: "Age_MY", type: Int64?},
+          luminosity: {key: "Luminosity", type: String?}
         )
       end
 

--- a/src/traikoa/eddn/data.cr
+++ b/src/traikoa/eddn/data.cr
@@ -101,7 +101,8 @@ module Traikoa
           station_faction_economy: {key: "StationEconomy", type: String, converter: Localizer::Economy},
           distance_from_star: {key: "DistFromStarLS", type: Float64},
           station_type: {key: "StationType", type: String},
-          station_name: {key: "StationName", type: String}
+          station_name: {key: "StationName", type: String},
+          station_services: {key: "StationServices", type: Array(String)}
         )
       end
 
@@ -119,7 +120,8 @@ module Traikoa
           factions: {key: "Factions", type: Array(Faction)?},
           docked: {key: "Docked", type: Bool?},
           station_type: {key: "StationType", type: String?},
-          station_name: {key: "StationName", type: String?}
+          station_name: {key: "StationName", type: String?},
+          population: {key: "Population", type: UInt64}
         )
       end
 

--- a/src/traikoa/eddn/parser.cr
+++ b/src/traikoa/eddn/parser.cr
@@ -14,6 +14,10 @@ module Traikoa
       end
     end
 
+    # Exception to raise on unimplemented events
+    class NotImplemented < Exception
+    end
+
     module Journal
       # Pulls out the kind of journal event a message is for
       def self.read_event(message : IO::Memory)
@@ -31,11 +35,9 @@ module Traikoa
         {% for kind in Events %}
           return {{kind.id}}.from_json message if event == {{kind}}
         {% end %}
-      end
-    end
 
-    # Exception to raise on unimplemented events
-    class NotImplemented < Exception
+        raise NotImplemented.new("Unknown Journal event: #{event}")
+      end
     end
 
     # TODO


### PR DESCRIPTION
Opening this issue to track development of this branch & keep a TODO / any thoughts I have along the way. This will implement one of the major compilation targets (#10 ), the EDDN listener that connects the gateway and the database, which for now I've decided will use its own database connection to issue updates (as opposed to implementing the REST API - I still may do this at a later date, but for now this is simpler)

---
**Todo:**
- [ ] Station Schema (#5)
- [ ] Decide on `eddn_logs` polling model or an asynchronous match-up to `eddn_logs` after processing. See below for ramblings on this. In either case, the logs should be annotated with how the rest of the application handled the EDDN packet.
- [ ] Determine how validation rules will be implemented (table? model validation?)
- [ ] Determine how blacklisting (beyond schema URL class map) will be implemented

---
### `eddn_logs` "backfilling" rambling
```
[10:15 AM] z64: so currently everything goes through an on_packet handler for logging every event that comes through.

what I think i might do is add columns to the logging table that will be null, but filled in later, that reflect how the rest of the application processed the message async ; i.e. status (enum) and message (text)

so I would have another thread that polls the logging table with status = 'new', and handles each new row, and updates the logging row with the result (success, error, warning)
[10:16 AM] z64: alternatively I would use the event handlers like on_journal_fsd_jump, and once its done, search for its corresponding logging row and update it
[10:17 AM] z64: however i don't know that I can guarentee the logging row will always be there if the on_journal_fsd_jump handler finishes before the on_packet logging handler
[10:18 AM] z64: i could possibly reimplement the other handlers to work off of postgres PUBLISH that fires after the logging row insert
[10:18 AM] z64: unsure how this will work with my ORM though
[10:18 AM] z64: i know the driver supports it
[10:22 AM] z64: another option is to make a seperate logging table for the other handlers that looks up and references a fkey of the logging event, and for browsing history I can JOIN the two together
```
